### PR TITLE
TravisCi: Add Tasks To Run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ cache:
   directories:
     - "node_modules"
 
+script:
+- npm run build 
+- npm run lint
+- npm run test
+
 after_success:
   - npm run generate:docs
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
+    "build": "ng build ng-dnd",
+    "build:doc": "ng build",
+    "test": "ng test ng-dnd",
+    "test:doc": "ng test",
+    "lint": "ng lint ng-dnd",
+    "lint:doc": "ng lint",
     "e2e": "ng e2e",
     "generate:docs": "ng build --prod --output-path=docs --base-href https://clipchamp.github.io/ng-dnd/"
   },


### PR DESCRIPTION
This PR suggests using the `build`, `lint` and `test` commands to be based on the ng-dnd library, rather than the base (docs). And as such, adds these to the travis CI tasks.